### PR TITLE
1.0.4 Parse response so data can be returned. Add all status callback

### DIFF
--- a/fetchy.ts
+++ b/fetchy.ts
@@ -1,13 +1,14 @@
-type FetchyOptions = Omit<RequestInit, "method">
-
-function maybeThrowError(response: Response) {
-  if (response.status >= 400) throw response
+async function maybeThrowError(response: Response) {
+  if (!response.ok) {
+    const parsedResponse = await response.json()
+    throw parsedResponse
+  }
 }
 
 async function makeRequest<T>(
   url: string,
   method: "GET" | "PUT" | "POST" | "DELETE",
-  options?: FetchyOptions
+  options?: Omit<RequestInit, "method">
 ) {
   const response = await fetch(url, { ...options, method })
 
@@ -33,11 +34,16 @@ const fetchy = {
 
 export function handleStatus(
   e: any,
-  callbacks?: { [key: number]: (e?: any) => void }
+  callbacks?: { [key: number | string]: (e?: any) => void }
 ) {
   if (callbacks && callbacks[e.status]) {
     const callback = callbacks[e.status]
     return callback(e)
+  }
+
+  if (callbacks && callbacks["all"]) {
+    const callback = callbacks["all"]
+    callback(e)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A wrapper for JavaScript's fetch method that throws errors on 400 and 500 responses and accepts TypeScript generics for type-safe returns.",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
- When throwing errors, throw a parsed response so that any additional data can be utilized by callbacks
- Add an "all" status callback for executing on any error status