### PR TITLE
1.1.0 More error support, Use fields key, add other status catch all

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ type CallbackConfig = {
     [key: string | number]: (e?: any) => void
     all?: (e?: any) => void
   }
+  onFailure?: {
+    fetch?: (e?:any) => void
+    network?: (e?:any) => void
+    abort?: (e?:any) => void
+    security?: (e?:any) => void
+    syntax?: (e?:any) => void
+    all?: (e?:any) => void
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,11 @@ function handleError(e: any, callbacks?: CallbackConfig)
 type CallbackConfig = {
   status?: {
     [key: number]: (e?: any) => void
-    other?: (e?:any) => void
+    other?: (e?: any) => void
     all?: (e?: any) => void
   }
   field?: {
-    [key: string | number]: {
-      [key: string | number | "all"]: (e?: any, value?: any) => void
-    }
+    [key: string | number]: (e?: any, value?: any) => void
   }
   onFailure?: {
     fetch?: (e?: any) => void

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ async function getUserAndGreet() {
   } catch (e: any) {
     handleError(e, {
       field: {
-        errorMessage: (e, value: any) => {
+        errorMessage: (e, value) => {
           switch (value) {
             case "USER_NOT_ACTIVE":
               // Do something if response includes { errorMessage: "USER_NOT_ACTIVE "}
@@ -167,7 +167,7 @@ async function getUserAndGreet() {
         },
       },
       field: {
-        errorMessage: (e, value: any) => {
+        errorMessage: (e, value) => {
           switch (value) {
             case "USER_NOT_ACTIVE":
               // Do something if response includes { errorMessage: "USER_NOT_ACTIVE "}

--- a/README.md
+++ b/README.md
@@ -32,19 +32,21 @@ function handleError(e: any, callbacks?: CallbackConfig)
 type CallbackConfig = {
   status?: {
     [key: number]: (e?: any) => void
+    other?: (e?:any) => void
     all?: (e?: any) => void
   }
-  customKey?: {
-    [key: string | number]: (e?: any) => void
-    all?: (e?: any) => void
+  field?: {
+    [key: string | number]: {
+      [key: string | number | "all"]: (e?: any, value?: any) => void
+    }
   }
   onFailure?: {
-    fetch?: (e?:any) => void
-    network?: (e?:any) => void
-    abort?: (e?:any) => void
-    security?: (e?:any) => void
-    syntax?: (e?:any) => void
-    all?: (e?:any) => void
+    fetch?: (e?: any) => void
+    network?: (e?: any) => void
+    abort?: (e?: any) => void
+    security?: (e?: any) => void
+    syntax?: (e?: any) => void
+    all?: (e?: any) => void
   }
 }
 ```
@@ -101,6 +103,9 @@ async function getUserAndGreet() {
         500: (e) => {
           /* Do something if 500 response */
         },
+        other: (e) => {
+          /* Do something on any other non 200-300 statuses */
+        },
         all: (e) => {
           /* Do something on any non 200-300 status */
         },
@@ -122,15 +127,18 @@ async function getUserAndGreet() {
     greetUser(myUser)
   } catch (e: any) {
     handleError(e, {
-      errorMessage: {
-        USER_NOT_ACTIVE: (e) => {
-          /* Do something if error response includes { errorMessage: "USER_NOT_ACTIVE" */
-        },
-        USER_NOT_FOUND: (e) => {
-          /* Do something if error response includes { errorMessage: "USER_NOT_FOUND" */
-        },
-        all: (e) => {
-          /* Do something if error response includes { errorMessage: <anything> } */
+      field: {
+        errorMessage: (e, value: any) => {
+          switch (value) {
+            case "USER_NOT_ACTIVE":
+              // Do something if response includes { errorMessage: "USER_NOT_ACTIVE "}
+              break
+            case "USER_NOT_FOUND":
+              // Do something if response includes { errorMessage: "USER_NOT_FOUND "}
+              break
+            default:
+            // Do something if response includes { errorMessage: <anything else> }
+          }
         },
       },
     })
@@ -152,14 +160,6 @@ async function getUserAndGreet() {
     greetUser(myUser)
   } catch (e: any) {
     handleError(e, {
-      errorMessage: {
-        USER_NOT_ACTIVE: (e) => {
-          /* Do something if error response includes { errorMessage: "USER_NOT_ACTIVE" */
-        },
-        all: (e) => {
-          /* Do something if error response includes { errorMessage: <anything> } */
-        },
-      },
       status: {
         401: (e) => {
           /* Do something if 401 response */
@@ -167,8 +167,19 @@ async function getUserAndGreet() {
         500: (e) => {
           /* Do something if 500 response */
         },
-        all: (e) => {
-          /* Do something on any non 200-300 status */
+      },
+      field: {
+        errorMessage: (e, value: any) => {
+          switch (value) {
+            case "USER_NOT_ACTIVE":
+              // Do something if response includes { errorMessage: "USER_NOT_ACTIVE "}
+              break
+            case "USER_NOT_FOUND":
+              // Do something if response includes { errorMessage: "USER_NOT_FOUND "}
+              break
+            default:
+            // Do something if response includes { errorMessage: <anything else> }
+          }
         },
       },
     })

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -146,7 +146,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
   // Handle any custom field server errors
 
-  Object.keys(callbacks.field ?? {}).forEach((key) => {
+  Object.keys(e).forEach((key) => {
     if (key !== "status" && callbacks.field && callbacks.field[key]) {
       const callback = callbacks.field[key]
       callback(e, e[key])

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -37,10 +37,11 @@ const fetchy = {
 type CallbackConfig = {
   status?: {
     [key: number]: (e?: any) => void
+    other?: (e?: any) => void
     all?: (e?: any) => void
   }
   field?: {
-    [key: string | number | "all"]: (e?: any, value?: any) => void
+    [key: string | number]: (e?: any, value?: any) => void
   }
   onFailure?: {
     fetch?: (e?: any) => void
@@ -124,6 +125,17 @@ export function handleError(e: any, callbacks: CallbackConfig) {
     callback(e)
   }
 
+  // Handle other status errors
+
+  if (
+    callbacks.status &&
+    !callbacks.status[e.status] &&
+    callbacks.status.other
+  ) {
+    const callback = callbacks.status.other
+    callback(e)
+  }
+
   // Handle all status errors
 
   if (callbacks.status && callbacks.status.all) {
@@ -134,12 +146,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
   // Handle any custom field server errors
 
   Object.keys(callbacks.field ?? {}).forEach((key) => {
-    if (
-      e[key] &&
-      callbacks.field &&
-      callbacks.field[key] &&
-      !!callbacks.field[key]
-    ) {
+    if (key !== "status" && callbacks.field && callbacks.field[key]) {
       const callback = callbacks.field[key]
       callback(e, e[key])
     }

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -34,21 +34,114 @@ const fetchy = {
   },
 }
 
-export function handleError(
-  e: any,
-  callbacks?: {
-    [key: string]: { [key: number | string]: (e?: any) => void }
+type CallbackConfig = {
+  status?: {
+    [key: number]: (e?: any) => void
+    all?: (e?: any) => void
   }
-) {
-  Object.keys(callbacks ?? {}).forEach((key) => {
-    if (e[key] && callbacks && callbacks[key][e[key]]) {
-      const callback = callbacks[key][e[key]]
+  field?: {
+    [key: string | number | "all"]: (e?: any, value?: any) => void
+  }
+  onFailure?: {
+    fetch?: (e?: any) => void
+    network?: (e?: any) => void
+    abort?: (e?: any) => void
+    security?: (e?: any) => void
+    syntax?: (e?: any) => void
+    all?: (e?: any) => void
+  }
+}
+
+export function handleError(e: any, callbacks: CallbackConfig) {
+  // Handle non-server errors
+
+  if (callbacks && callbacks["onFailure"]) {
+    const allFailureCallback = callbacks["onFailure"]["all"]
+
+    // Handle specific TypeErrors
+
+    if (e instanceof TypeError) {
+      let callback: (e?: any) => void = () => {}
+
+      const fetchFailCallback = callbacks["onFailure"]["fetch"]
+      const networkFailCallback = callbacks["onFailure"]["network"]
+
+      const { message } = e
+
+      if (message.toLowerCase().includes("failed") && !!fetchFailCallback) {
+        callback = fetchFailCallback
+      }
+
+      if (message.toLowerCase().includes("network") && !!networkFailCallback) {
+        callback = networkFailCallback
+      }
+      callback(e)
+
+      if (!!allFailureCallback) allFailureCallback(e)
+    }
+
+    // Handle specific DOMExceptions
+
+    if (e instanceof DOMException) {
+      let callback: (e?: any) => void = () => {}
+
+      const abortCallback = callbacks["onFailure"]["abort"]
+      const securityCallback = callbacks["onFailure"]["security"]
+
+      const { message } = e
+
+      if (message.toLowerCase().includes("abort") && !!abortCallback) {
+        callback = abortCallback
+      }
+
+      if (message.toLowerCase().includes("security") && !!securityCallback) {
+        callback = securityCallback
+      }
       callback(e)
     }
 
-    if (e[key] && callbacks && callbacks[key] && callbacks[key]["all"]) {
-      const callback = callbacks[key]["all"]
-      callback(e)
+    // Handle SyntaxErrors
+
+    const syntaxCallback = callbacks["onFailure"]["syntax"]
+    if (e instanceof SyntaxError && !!syntaxCallback) {
+      syntaxCallback(e)
+    }
+
+    if (
+      (e instanceof TypeError ||
+        e instanceof DOMException ||
+        e instanceof SyntaxError) &&
+      !!allFailureCallback
+    ) {
+      return allFailureCallback(e)
+    }
+  }
+
+  // Handle specific status errors
+
+  if (callbacks.status && callbacks.status[e.status]) {
+    const callback = callbacks.status[e.status]
+    callback(e)
+  }
+
+  // Handle all status errors
+
+  if (callbacks.status && callbacks.status.all) {
+    const callback = callbacks.status.all
+    callback(e)
+  }
+
+  // Handle any custom field server errors
+
+  Object.keys(callbacks.field ?? {}).forEach((key) => {
+    if (
+      e[key] &&
+      callbacks.field &&
+      callbacks.field[key] &&
+      !!callbacks.field[key]
+    ) {
+      const callback = callbacks.field[key]
+      callback(e, e[key])
     }
   })
 }

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -120,7 +120,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
   // Handle specific status errors
 
-  if (callbacks.status && callbacks.status[e.status]) {
+  if (e.status && callbacks.status && callbacks.status[e.status]) {
     const callback = callbacks.status[e.status]
     callback(e)
   }
@@ -128,6 +128,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
   // Handle other status errors
 
   if (
+    e.status &&
     callbacks.status &&
     !callbacks.status[e.status] &&
     callbacks.status.other
@@ -138,7 +139,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
   // Handle all status errors
 
-  if (callbacks.status && callbacks.status.all) {
+  if (e.status && callbacks.status && callbacks.status.all) {
     const callback = callbacks.status.all
     callback(e)
   }

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -56,7 +56,7 @@ type CallbackConfig = {
 export function handleError(e: any, callbacks: CallbackConfig) {
   // Handle non-server errors
 
-  if (callbacks && callbacks["onFailure"]) {
+  if (callbacks["onFailure"]) {
     const allFailureCallback = callbacks["onFailure"]["all"]
 
     // Handle specific TypeErrors

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "A wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
- Add support for other local errors
- Add `other` option to status callbacks for catch-all w/o having to use `all` option
- Move customKey to field: customKey for better type inference