### PR TITLE
1.1.4 Handle DOM exceptions as generic errors

### DIFF
--- a/fetchy.ts
+++ b/fetchy.ts
@@ -87,19 +87,18 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
     // Handle specific DOMExceptions
 
-    let callback: (e?: any) => void = () => {}
-
     const abortCallback = callbacks["onFailure"]["abort"]
     const securityCallback = callbacks["onFailure"]["security"]
 
     if (e.message?.toLowerCase().includes("abort") && !!abortCallback) {
-      callback = abortCallback
+      const callback = abortCallback
+      callback(e)
     }
 
     if (e.message?.toLowerCase().includes("security") && !!securityCallback) {
-      callback = securityCallback
+      const callback = securityCallback
+      callback(e)
     }
-    callback(e)
 
     // Handle SyntaxErrors
 

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -87,23 +87,19 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
     // Handle specific DOMExceptions
 
-    if (e instanceof DOMException) {
-      let callback: (e?: any) => void = () => {}
+    let callback: (e?: any) => void = () => {}
 
-      const abortCallback = callbacks["onFailure"]["abort"]
-      const securityCallback = callbacks["onFailure"]["security"]
+    const abortCallback = callbacks["onFailure"]["abort"]
+    const securityCallback = callbacks["onFailure"]["security"]
 
-      const { message } = e
-
-      if (message.toLowerCase().includes("abort") && !!abortCallback) {
-        callback = abortCallback
-      }
-
-      if (message.toLowerCase().includes("security") && !!securityCallback) {
-        callback = securityCallback
-      }
-      callback(e)
+    if (e.message?.toLowerCase().includes("abort") && !!abortCallback) {
+      callback = abortCallback
     }
+
+    if (e.message?.toLowerCase().includes("security") && !!securityCallback) {
+      callback = securityCallback
+    }
+    callback(e)
 
     // Handle SyntaxErrors
 

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -81,11 +81,13 @@ export function handleError(e: any, callbacks: CallbackConfig) {
         callback = networkFailCallback
       }
       callback(e)
-
-      if (!!allFailureCallback) allFailureCallback(e)
     }
 
     // Handle specific DOMExceptions
+
+    const isDOMExceptionError =
+      e.message?.toLowerCase().includes("abort") ||
+      e.message?.toLowerCase().includes("security")
 
     const abortCallback = callbacks["onFailure"]["abort"]
     const securityCallback = callbacks["onFailure"]["security"]
@@ -109,7 +111,7 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
     if (
       (e instanceof TypeError ||
-        e instanceof DOMException ||
+        isDOMExceptionError ||
         e instanceof SyntaxError) &&
       !!allFailureCallback
     ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
- Switch to general error checking for DOMExceptions because React Native throws error when referencing DOMException