### PR TITLE
v2 - Don't throw errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Fetchy is an open source, zero dependency wrapper for JavaScript's fetch functio
 
 1. Simple get, post, put and delete functions
 2. Accepts TypeScript generics for type-safe returns.
-3. Returns errors rather than throwing them, removing the need to use try/catch blocks. (version ≥1.2.0)
-4. Easy handling of different types of fetch errors.
+3. Returns errors rather than throwing them, removing the need to use try/catch blocks. (version ≥2.0.0)
+4. Easily detects and handles different types of fetch errors.
 
 ## Documentation
 
@@ -20,8 +20,6 @@ Fetchy is an open source, zero dependency wrapper for JavaScript's fetch functio
    `import fetchy from "@gladknee/fetchy"`
 
 3. The imported object provides four functions for making requests: `get`, `post`, `put`, `delete`.
-
-_NOTE: The `error` key is returned in version ≥1.2.0. For earlier versions, the error is thrown like a normal rejected promise._
 
 ```typescript
 import fetchy from "@gladknee/fetchy"
@@ -44,6 +42,8 @@ const [data, error] = await fetchy.get("https://server.com/api/endpoint", {
   headers: { Authorization: "Bearer XXXXXX" },
 })
 ```
+
+_NOTE: For versions <2.0.0, the function returns an object with a `data` key. If an error occurs, the error is thrown._
 
 ### HTTP Methods
 
@@ -73,43 +73,41 @@ function delete<T = unknown>(
 ### Types
 
 ```typescript
-type FetchyResponse<T> = [
-  error: FetchyError | undefined,
-  data: T | undefined,
-  response: Response
-]
+type FetchyResponse<T> =
+  | [data: T, error: undefined, response: Response]
+  | [data: undefined, error: FetchyError, response: Response]
 
 export type FetchyError = Error | ({ status: number } & Record<string, any>)
 ```
 
 ### Error Handling
 
-The imported `fetchy` object contains a `handleError` method. You can call this function by passing two required parameters: the error and your error handling callback configuration.
+The imported `fetchy` object also contains a `handleError` method. You can call this function by passing two required parameters: the error and your error handling callback configuration.
 
-_NOTE: If you are using versions <1.2.0, you will need to import `handleError` separately from the fetchy default export. You will also need to call the function inside your catch block._
+_NOTE: If you are using versions <2.0.0, you will need to import `handleError` separately from the fetchy default export. You will also need to call the function inside your catch block._
 
 ```typescript
-function handleError(e: any, callbacks: CallbackConfig)
+function handleError(e: FetchyError, callbacks: CallbackConfig)
 
 type CallbackConfig = {
   status?: {
-    [key: number]: (e?: any) => void
-    other?: (e?: any) => void
-    all?: (e?: any) => void
+    [key: number]: (e?: FetchyError) => void
+    other?: (e?: FetchyError) => void
+    all?: (e?: FetchyError) => void
   }
   body?: {
-    [key: string | number]: (value?: any, e?: any) => void
+    [key: string]: (value?: any, e?: FetchyError) => void
   }
   client?: {
-    fetch?: (e?: any) => void
-    network?: (e?: any) => void
-    abort?: (e?: any) => void
-    security?: (e?: any) => void
-    syntax?: (e?: any) => void
-    all?: (e?: any) => void
+    fetch?: (e?: FetchyError) => void
+    network?: (e?: FetchyError) => void
+    abort?: (e?: FetchyError) => void
+    security?: (e?: FetchyError) => void
+    syntax?: (e?: FetchyError) => void
+    all?: (e?: FetchyError) => void
   }
-  other?: (e?: any) => void
-  all?: (e?: any) => void
+  other?: (e?: FetchyError) => void
+  all?: (e?: FetchyError) => void
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,106 +1,115 @@
 # fetchy
 
-Fetchy is a zero dependency wrapper for JavaScript's fetch method that automatically throws an error on non 200-300 statuses and accepts TypeScript generics for type-safe returns. It also provides error handling that allows you to easily execute different callbacks for different types of errors.
+Fetchy is an open source, zero dependency wrapper for JavaScript's fetch function. It provides the following benefits:
 
-IMPORTANT: The library currently only handles responses with text or JSON (or no) content types. I'll be adding support for other content types in the future.
+1. Simple get, post, put and delete functions
+2. Accepts TypeScript generics for type-safe returns.
+3. Returns errors rather than throwing them, removing the need to use try/catch blocks. (version ≥1.2.0)
+4. Easy handling of different types of fetch errors.
 
 ## Documentation
 
 ### Quick Start
 
-1. Install the package with `npm i @gladknee/fetchy`
-2. Import the default fetchy export from the library.
-3. The fetchy object provides four functions for making requests: `get`, `post`, `put`, `delete`.
-4. A successful request returns a native `Response` with an additional `data` key containing any parsed JSON or text.
+1. Install the package.
+
+   `npm i @gladknee/fetchy`
+
+2. Import the default export from the library.
+
+   `import fetchy from "@gladknee/fetchy"`
+
+3. The imported object provides four functions for making requests: `get`, `post`, `put`, `delete`.
+
+_NOTE: The `error` key is returned in version ≥1.2.0. For earlier versions, the error is thrown like a normal rejected promise._
 
 ```typescript
 import fetchy from "@gladknee/fetchy"
 
-// async await method
-
 async function yourFunction() {
-  try {
-    const { data } = await fetchy.get("https://server.com/api/endpoint")
-  } catch (e: any) {}
-}
+  const [data, error, response] = await fetchy.get(
+    "https://server.com/api/endpoint"
+  )
 
-// Chaining method
-
-fetchy
-  .get("https://server.com/api/endpoint")
-  .then(({ data }) => {})
-  .catch((e: any) => {})
-```
-
-### Methods
-
-```typescript
-type FetchyResponse<T> = Response & { data: T }
-
-function get<T = any>(
-  url: string,
-  options?: Omit<RequestInit, "method">
-): Promise<FetchyResponse<T>> {}
-
-function post<T = any>(
-  url: string,
-  options?: Omit<RequestInit, "method">
-): Promise<FetchyResponse<T>> {}
-
-function put<T = any>(
-  url: string,
-  options?: Omit<RequestInit, "method">
-): Promise<FetchyResponse<T>> {}
-
-function delete<T = any>(
-  url: string,
-  options?: Omit<RequestInit, "method">
-): Promise<FetchyResponse<T>> {}
-
-```
-
-### Examples
-
-We have a `User` type and `greetUser()` function that accepts a User. We'll create a `getUser()` function that makes a GET request to fetch the user and pass it to the greetUser function.
-
-```typescript
-type User = { id: number; name: string }
-
-function greetUser(user: User) {
-  alert(`Hello ${user.name}`)
-}
-
-async function getUser() {
-  const { data } = await fetchy.get<User>("https://server.com/api/users/me", {
-    headers: { Authorization: "Bearer XXXXXX" },
-  })
-  return data
-}
-
-async function getAndGreetUser() {
-  try {
-    const user = await getUser()
-
-    greetUser(user)
-  } catch (e: any) {
+  if (data) {
+    // handle returned data
+  } else {
     // handle error
   }
 }
+
+// You can also pass config options like a normal fetch call...
+
+const [data, error] = await fetchy.get("https://server.com/api/endpoint", {
+  headers: { Authorization: "Bearer XXXXXX" },
+})
+```
+
+### HTTP Methods
+
+```typescript
+function get<T = unknown>(
+  url: string,
+  options?: Omit<RequestInit, "method">
+): Promise<FetchyResponse<T>> {}
+
+function post<T = unknown>(
+  url: string,
+  options?: Omit<RequestInit, "method">
+): Promise<FetchyResponse<T>> {}
+
+function put<T = unknown>(
+  url: string,
+  options?: Omit<RequestInit, "method">
+): Promise<FetchyResponse<T>> {}
+
+function delete<T = unknown>(
+  url: string,
+  options?: Omit<RequestInit, "method">
+): Promise<FetchyResponse<T>> {}
+
+```
+
+### Types
+
+```typescript
+type FetchyResponse<T> = [
+  error: FetchyError | undefined,
+  data: T | undefined,
+  response: Response
+]
+
+export type FetchyError = Error | ({ status: number } & Record<string, any>)
 ```
 
 ### Error Handling
 
-Import the `handleError` function from the library. You can then call this function inside your catch block by passing two required parameters: the error and your error handling callback configuration.
+The imported `fetchy` object contains a `handleError` method. You can call this function by passing two required parameters: the error and your error handling callback configuration.
+
+_NOTE: If you are using versions <1.2.0, you will need to import `handleError` separately from the fetchy default export. You will also need to call the function inside your catch block._
 
 ```typescript
-import fetchy, { handleError } from "@gladknee/fetchy"
+function handleError(e: any, callbacks: CallbackConfig)
 
-async function someRequest() {
-  try {
-    const { data } = await fetchy.get("https://server.com/api")
-  } catch (e: any) {
-    handleError(e, callbackConfig)
+type CallbackConfig = {
+  status?: {
+    [key: number]: (e?: any) => void
+    other?: (e?: any) => void
+    all?: (e?: any) => void
   }
+  body?: {
+    [key: string | number]: (value?: any, e?: any) => void
+  }
+  client?: {
+    fetch?: (e?: any) => void
+    network?: (e?: any) => void
+    abort?: (e?: any) => void
+    security?: (e?: any) => void
+    syntax?: (e?: any) => void
+    all?: (e?: any) => void
+  }
+  other?: (e?: any) => void
+  all?: (e?: any) => void
 }
 ```
 
@@ -108,23 +117,23 @@ async function someRequest() {
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const [data, error] = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       status: {
-        401: (e) => {
+        401: (error) => {
           /* Do something if 401 response */
         },
-        500: (e) => {
+        500: (error) => {
           /* Do something if 500 response */
         },
-        other: (e) => {
+        other: (error) => {
           /* Do something on any other non 200-300 statuses */
         },
-        all: (e) => {
+        all: (error) => {
           /* Do something on any non 200-300 status */
         },
       },
@@ -137,14 +146,14 @@ async function getAndGreetUser() {
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const [data, error] = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       body: {
-        fieldName: (e, value) => {
+        fieldName: (value, error) => {
           switch (value) {
             case "SOME_VALUE":
               // Do something if response includes { fieldName: "SOME_VALUE" }
@@ -166,29 +175,29 @@ async function getAndGreetUser() {
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const [data, error] = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       client: {
-        fetch: (e) => {
+        fetch: (error) => {
           /* Do something if fetch failed */
         },
-        network: (e) => {
+        network: (error) => {
           /* Do something if network error */
         },
-        abort: (e) => {
+        abort: (error) => {
           /* Do something if user aborted */
         },
-        security: (e) => {
+        security: (error) => {
           /* Do something if security error */
         },
-        syntax: (e) => {
+        syntax: (error) => {
           /* Do something if syntax error */
         },
-        all: (e) => {
+        all: (error) => {
           /* Do something if any client-side error */
         },
       },
@@ -201,18 +210,18 @@ async function getAndGreetUser() {
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const [data, error] = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       status: {
-        401: (e) => {
+        401: (error) => {
           /* Do something if 401 response */
         },
       },
-      other: (e) => {
+      other: (error) => {
         /* Do something if any other error is thrown */
       },
     })
@@ -222,22 +231,21 @@ async function getAndGreetUser() {
 
 #### Handling all errors
 
-You can also execute a callback on any error. This will be executed along with any other triggered callbacks. So in this example, on a 401 or 409 error, the user is redirected and the error is logged.
+You can also execute a callback on any error. This will be executed along with any other triggered callbacks. So in this example, on a 401 error, the user is redirected and the error is logged.
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const [data, error] = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       status: {
         401: () => redirect("/auth"),
-        402: () => redirect("/upgrade"),
       },
-      all: (e) => {
-        logError(e)
+      all: (error) => {
+        logError(error)
       },
     })
   }
@@ -250,17 +258,17 @@ _NOTE: If multiple error handling conditions are triggered, each of their callba
 
 ```typescript
 async function getAndGreetUser() {
-  try {
-    const user = await getUser()
+  const { data, error } = await fetchy.get("https://api.com/users/1")
 
-    greetUser(user)
-  } catch (e: any) {
-    handleError(e, {
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleError(error, {
       status: {
         401: () => redirect("/auth"),
       },
       body: {
-        errorMessage: (e, value) => {
+        errorMessage: (value, error) => {
           switch (value) {
             case "USER_NOT_ACTIVE":
               alert("Your account is no longer active.")
@@ -273,34 +281,9 @@ async function getAndGreetUser() {
       client: {
         network: () => alert("There was a network error."),
       },
-      all: (e) => logError(e),
+      all: (error) => logError(error),
     })
   }
-}
-```
-
-Here's the full type definition of a callback configuration:
-
-```typescript
-type CallbackConfig = {
-  status?: {
-    [key: number]: (e?: any) => void
-    other?: (e?: any) => void
-    all?: (e?: any) => void
-  }
-  body?: {
-    [key: string | number]: (e?: any, value?: any) => void
-  }
-  client?: {
-    fetch?: (e?: any) => void
-    network?: (e?: any) => void
-    abort?: (e?: any) => void
-    security?: (e?: any) => void
-    syntax?: (e?: any) => void
-    all?: (e?: any) => void
-  }
-  other?: (e?: any) => void
-  all?: (e?: any) => void
 }
 ```
 
@@ -311,10 +294,12 @@ As you can see in the previous example, combining multiple types of error handli
 Example:
 
 ```typescript
+import type { CallbackConfig } from "@gladknee/fetchy"
+
 const handleStatusErrors = {
   401: () => router.push("/auth/signin"),
   402: () => router.push("/upgrade"),
-  500: (e: any?) => logInternalServerError(e),
+  500: (error: any) => logInternalServerError(eror),
   // ...etc
 }
 
@@ -323,12 +308,12 @@ const handleClientErrors = {
   network: () => alert("We experienced a network error. Please try again."),
 }
 
-const handleErrorMessages = (e: any, message: string) => {
+const handleErrorMessages = (message: string) => {
   switch (message) {
     case "USER_NOT_FOUND":
       alert("You do not have an account.")
       break
-    case "USER_DEACTIVED":
+    case "USER_DEACTIVATED":
       alert("Your account has been deactivated.")
       break
     default:
@@ -336,11 +321,11 @@ const handleErrorMessages = (e: any, message: string) => {
   }
 }
 
-function logError(e: any) {
+function logError(error: any) {
   // do something to log any errors
 }
 
-const myErrorHandlers = {
+const myErrorHandlers: CallbackConfig = {
   status: handleStatusErrors,
   client: handleClientErrors,
   body: {
@@ -350,10 +335,12 @@ const myErrorHandlers = {
 }
 
 async function someRequest() {
-  try {
-    const { data } = await fetchy.get("url")
-  } catch (e: any) {
-    handleErrors(e, myErrorHandlers)
+  const { data, error } = await fetchy.get("https://api.com/users/1")
+
+  if (data) {
+    greetUser(data)
+  } else {
+    fetchy.handleErrors(error, myErrorHandlers)
   }
 }
 ```
@@ -364,8 +351,10 @@ Fetchy works great with Tanstack Query. Below is a popular implementation.
 
 ```typescript
 export async function getUser() {
-  const { data } = await fetchy.get("https://server.com/api/users/me")
-  return data
+  const { data, error } = await fetchy.get("https://api.com/users/1")
+
+  if (data) return data
+  else throw error // Throw the error so that it bubbles up to your useQuery hook
 }
 
 export function SomeComponent() {
@@ -376,7 +365,7 @@ export function SomeComponent() {
 
   useEffect(() => {
     if (isError) {
-      handleError(error, callbackConfig)
+      fetchy.handleError(error, callbackConfig)
     }
   }, [isError, error])
 }

--- a/fetchy.spec.ts
+++ b/fetchy.spec.ts
@@ -1,18 +1,19 @@
-import { handleError } from "./fetchy"
+import fetchy from "./fetchy"
 
 async function mockResponse(body: any) {
   return new Promise((_, reject) => reject(body))
 }
 
-describe("handleError", () => {
+describe("fetchy.handleError", () => {
   it("calls specific status callbacks", async () => {
     const callback401 = jest.fn()
     const callback409 = jest.fn()
-    try {
-      await mockResponse({ status: 401 })
-    } catch (e: any) {
-      handleError(e, { status: { 401: callback401, 409: callback409 } })
-    }
+
+    const error = { status: 401 }
+
+    fetchy.handleError(error, {
+      status: { 401: callback401, 409: callback409 },
+    })
 
     expect(callback401).toHaveBeenCalled()
     expect(callback409).not.toHaveBeenCalled()
@@ -21,11 +22,12 @@ describe("handleError", () => {
   it("calls status.other callbacks", async () => {
     const callback401 = jest.fn()
     const otherCallback = jest.fn()
-    try {
-      await mockResponse({ status: 500 })
-    } catch (e: any) {
-      handleError(e, { status: { 401: callback401, other: otherCallback } })
-    }
+
+    const error = { status: 500 } as Response
+
+    fetchy.handleError(error, {
+      status: { 401: callback401, other: otherCallback },
+    })
 
     expect(callback401).not.toHaveBeenCalled()
     expect(otherCallback).toHaveBeenCalled()
@@ -35,13 +37,12 @@ describe("handleError", () => {
     const callback401 = jest.fn()
     const callback409 = jest.fn()
     const callbackAll = jest.fn()
-    try {
-      await mockResponse({ status: 409 })
-    } catch (e: any) {
-      handleError(e, {
-        status: { 401: callback401, 409: callback409, all: callbackAll },
-      })
-    }
+
+    const error = { status: 409 } as Response
+
+    fetchy.handleError(error, {
+      status: { 401: callback401, 409: callback409, all: callbackAll },
+    })
 
     expect(callback409).toHaveBeenCalled()
     expect(callbackAll).toHaveBeenCalled()
@@ -51,97 +52,88 @@ describe("handleError", () => {
   it("calls specific key/value callbacks", async () => {
     const badThingCallback = jest.fn()
     const otherBadThingCallback = jest.fn()
-    try {
-      await mockResponse({ status: 500, error_message: "BAD_THING" })
-    } catch (e: any) {
-      handleError(e, {
-        body: {
-          error_message: badThingCallback,
-        },
-      })
-    }
 
-    expect(badThingCallback).toHaveBeenCalledWith(
-      { status: 500, error_message: "BAD_THING" },
-      "BAD_THING"
-    )
+    const error = { status: 500, error_message: "BAD_THING" }
+
+    fetchy.handleError(error, {
+      body: {
+        error_message: badThingCallback,
+      },
+    })
+
+    expect(badThingCallback).toHaveBeenCalledWith("BAD_THING", {
+      status: 500,
+      error_message: "BAD_THING",
+    })
     expect(otherBadThingCallback).not.toHaveBeenCalled()
   })
 
   it("calls client.fetch callback", () => {
     const fetchFailCallback = jest.fn()
-    try {
-      throw new TypeError("fetch failed")
-    } catch (e) {
-      handleError(e, {
-        client: { fetch: fetchFailCallback },
-      })
-    }
+
+    const error = new TypeError("fetch failed")
+
+    fetchy.handleError(error, {
+      client: { fetch: fetchFailCallback },
+    })
 
     expect(fetchFailCallback).toHaveBeenCalled()
   })
 
   it("calls client.network callback", () => {
     const networkFailCallback = jest.fn()
-    try {
-      throw new TypeError("Network error")
-    } catch (e) {
-      handleError(e, {
-        client: { network: networkFailCallback },
-      })
-    }
+    const error = new TypeError("Network error")
+
+    fetchy.handleError(error, {
+      client: { network: networkFailCallback },
+    })
 
     expect(networkFailCallback).toHaveBeenCalled()
   })
 
   it("calls client.abort callback", () => {
     const abortCallback = jest.fn()
-    try {
-      throw new DOMException("abort")
-    } catch (e) {
-      handleError(e, {
-        client: { abort: abortCallback },
-      })
-    }
+
+    const error = new DOMException("abort")
+
+    fetchy.handleError(error, {
+      client: { abort: abortCallback },
+    })
 
     expect(abortCallback).toHaveBeenCalled()
   })
 
   it("calls client.security callback", () => {
     const securityCallback = jest.fn()
-    try {
-      throw new DOMException("security")
-    } catch (e) {
-      handleError(e, {
-        client: { security: securityCallback },
-      })
-    }
+
+    const error = new DOMException("security")
+
+    fetchy.handleError(error, {
+      client: { security: securityCallback },
+    })
 
     expect(securityCallback).toHaveBeenCalled()
   })
 
   it("calls client.syntax callback", () => {
     const syntaxFailureCallback = jest.fn()
-    try {
-      throw new SyntaxError("Unexpected token")
-    } catch (e) {
-      handleError(e, {
-        client: { syntax: syntaxFailureCallback },
-      })
-    }
+
+    const error = new SyntaxError("Unexpected token")
+
+    fetchy.handleError(error, {
+      client: { syntax: syntaxFailureCallback },
+    })
 
     expect(syntaxFailureCallback).toHaveBeenCalled()
   })
 
   it("calls client.all callback", () => {
     const allFailureCallback = jest.fn()
-    try {
-      throw new DOMException("security")
-    } catch (e) {
-      handleError(e, {
-        client: { all: allFailureCallback },
-      })
-    }
+    const error = new DOMException("security")
+
+    fetchy.handleError(error, {
+      client: { all: allFailureCallback },
+    })
 
     expect(allFailureCallback).toHaveBeenCalled()
   })
@@ -149,14 +141,13 @@ describe("handleError", () => {
   it("does not call client callbacks on success", async () => {
     const callback401 = jest.fn()
     const fetchFailureCallback = jest.fn()
-    try {
-      await mockResponse({ status: 401 })
-    } catch (e: any) {
-      handleError(e, {
-        status: { 401: callback401 },
-        client: { fetch: fetchFailureCallback },
-      })
-    }
+
+    const error = { status: 401 }
+
+    fetchy.handleError(error, {
+      status: { 401: callback401 },
+      client: { fetch: fetchFailureCallback },
+    })
 
     expect(callback401).toHaveBeenCalled()
     expect(fetchFailureCallback).not.toHaveBeenCalled()
@@ -168,35 +159,33 @@ describe("handleError", () => {
     const callbackFailed = jest.fn()
     const otherCallback = jest.fn()
 
-    try {
-      await mockResponse("SOME_RANDOM_ERROR")
-    } catch (e) {
-      handleError(e, {
-        status: { 401: callback401 },
-        body: { fieldName: callbackField },
-        client: { fetch: callbackFailed },
-        other: otherCallback,
-      })
-    }
+    const error = new Error("SOME_RANDOM_ERROR")
+
+    fetchy.handleError(error, {
+      status: { 401: callback401 },
+      body: { fieldName: callbackField },
+      client: { fetch: callbackFailed },
+      other: otherCallback,
+    })
+
     expect(callback401).not.toHaveBeenCalled()
     expect(callbackField).not.toHaveBeenCalled()
     expect(callbackFailed).not.toHaveBeenCalled()
-    expect(otherCallback).toHaveBeenCalledWith("SOME_RANDOM_ERROR")
+    expect(otherCallback).toHaveBeenCalledWith(Error("SOME_RANDOM_ERROR"))
   })
 
   it("does not call other callback if another callbacks is triggered", async () => {
     const callback401 = jest.fn()
     const otherCallback = jest.fn()
 
-    try {
-      await mockResponse({ status: 401 })
-    } catch (e) {
-      handleError(e, {
-        status: { 401: callback401 },
+    const error = { status: 401 }
 
-        other: otherCallback,
-      })
-    }
+    fetchy.handleError(error, {
+      status: { 401: callback401 },
+
+      other: otherCallback,
+    })
+
     expect(callback401).toHaveBeenCalled()
     expect(otherCallback).not.toHaveBeenCalled()
   })
@@ -207,19 +196,18 @@ describe("handleError", () => {
     const callbackFailed = jest.fn()
     const otherCallback = jest.fn()
 
-    try {
-      throw "SOME_RANDOM_ERROR"
-    } catch (e) {
-      handleError(e, {
-        status: { 401: callback401 },
-        body: { fieldName: callbackField },
-        client: { fetch: callbackFailed },
-        other: otherCallback,
-      })
-    }
+    const error = new Error("SOME_RANDOM_ERROR")
+
+    fetchy.handleError(error, {
+      status: { 401: callback401 },
+      body: { fieldName: callbackField },
+      client: { fetch: callbackFailed },
+      other: otherCallback,
+    })
+
     expect(callback401).not.toHaveBeenCalled()
     expect(callbackField).not.toHaveBeenCalled()
     expect(callbackFailed).not.toHaveBeenCalled()
-    expect(otherCallback).toHaveBeenCalledWith("SOME_RANDOM_ERROR")
+    expect(otherCallback).toHaveBeenCalledWith(Error("SOME_RANDOM_ERROR"))
   })
 })

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -1,4 +1,8 @@
-export type FetchyResponse<T> = Response & { data: T | null }
+export type FetchyResponse<T> =
+  | [T, undefined, Response]
+  | [undefined, FetchyError, Response]
+
+export type FetchyError = Error | ({ status: number } & Record<string, any>)
 
 async function getResponseData<T>(response: Response) {
   const contentType = response.headers.get("content-type")?.split(";")[0]
@@ -14,19 +18,19 @@ async function getResponseData<T>(response: Response) {
   }
 }
 
-async function maybeThrowError<T>(response: Response) {
-  const isJsonResponse = response.headers.get("content-type")?.includes("json")
+async function maybeReturnError<T>(
+  response: Response
+): Promise<FetchyResponse<T>> {
   if (response.ok) {
-    return {
-      ...response,
-      data: await getResponseData<T>(response),
-    } as FetchyResponse<T>
-  } else if (isJsonResponse) {
-    const parsedResponse = await response.json()
-    throw { status: response.status, ...parsedResponse }
+    return [await getResponseData<T>(response), undefined, response]
   } else {
-    throw response
+    const parsedResponse = await response.json()
+    return [undefined, { status: response.status, ...parsedResponse }, response]
   }
+}
+
+function returnError<T>(response: Response, e: any): FetchyResponse<T> {
+  return [undefined, e, response]
 }
 
 async function makeRequest<T>(
@@ -34,27 +38,41 @@ async function makeRequest<T>(
   method: "GET" | "PUT" | "POST" | "DELETE",
   options?: Omit<RequestInit, "method">
 ) {
-  const response = await fetch(url, { ...options, method })
-
-  return maybeThrowError<T>(response)
+  let response: Response | null = null
+  try {
+    response = await fetch(url, { ...options, method })
+    return maybeReturnError<T>(response)
+  } catch (e) {
+    return returnError<T>(response!, e)
+  }
 }
 
 const fetchy = {
-  get: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
+  get: async <T = unknown>(
+    url: string,
+    options?: Omit<RequestInit, "method">
+  ) => {
     return makeRequest<T>(url, "GET", options)
   },
-  put: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
+  put: async <T = unknown>(
+    url: string,
+    options?: Omit<RequestInit, "method">
+  ) => {
     return makeRequest<T>(url, "PUT", options)
   },
-  post: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
+  post: async <T = unknown>(
+    url: string,
+    options?: Omit<RequestInit, "method">
+  ) => {
     return makeRequest<T>(url, "POST", options)
   },
-  delete: async <T = any>(
+  delete: async <T = unknown>(
     url: string,
     options?: Omit<RequestInit, "method">
   ) => {
     return makeRequest<T>(url, "DELETE", options)
   },
+  handleError,
 }
 
 export type CallbackConfig = {
@@ -64,7 +82,7 @@ export type CallbackConfig = {
     all?: (e?: any) => void
   }
   body?: {
-    [key: string | number]: (e?: any, value?: any) => void
+    [key: string | number]: (value?: any, e?: any) => void
   }
   client?: {
     fetch?: (e?: any) => void
@@ -78,7 +96,7 @@ export type CallbackConfig = {
   all?: (e?: any) => void
 }
 
-export function handleError(e: any, callbacks: CallbackConfig) {
+function handleError(error: FetchyError, callbacks: CallbackConfig) {
   let errorThrown = false
   // Handle non-server errors
 
@@ -87,13 +105,13 @@ export function handleError(e: any, callbacks: CallbackConfig) {
 
     // Handle specific TypeErrors
 
-    if (e instanceof TypeError) {
+    if (error instanceof TypeError) {
       let callback: (e?: any) => void = () => {}
 
       const fetchFailCallback = callbacks.client["fetch"]
       const networkFailCallback = callbacks.client["network"]
 
-      const { message } = e
+      const { message } = error
 
       if (message.toLowerCase().includes("failed") && !!fetchFailCallback) {
         callback = fetchFailCallback
@@ -102,99 +120,109 @@ export function handleError(e: any, callbacks: CallbackConfig) {
       if (message.toLowerCase().includes("network") && !!networkFailCallback) {
         callback = networkFailCallback
       }
-      callback(e)
+      callback(error)
       errorThrown = true
     }
 
     // Handle specific DOMExceptions
 
     const isDOMExceptionError =
-      e.message?.toLowerCase().includes("abort") ||
-      e.message?.toLowerCase().includes("security")
+      error instanceof DOMException &&
+      (error.message?.toLowerCase().includes("abort") ||
+        error.message?.toLowerCase().includes("security"))
 
-    const abortCallback = callbacks.client["abort"]
-    const securityCallback = callbacks.client["security"]
+    if (isDOMExceptionError) {
+      const abortCallback = callbacks.client["abort"]
+      const securityCallback = callbacks.client["security"]
 
-    if (e.message?.toLowerCase().includes("abort") && !!abortCallback) {
-      const callback = abortCallback
-      callback(e)
-      errorThrown = true
-    }
+      if (error.message?.toLowerCase().includes("abort") && !!abortCallback) {
+        const callback = abortCallback
+        callback(error)
+        errorThrown = true
+      }
 
-    if (e.message?.toLowerCase().includes("security") && !!securityCallback) {
-      const callback = securityCallback
-      callback(e)
-      errorThrown = true
+      if (
+        error.message?.toLowerCase().includes("security") &&
+        !!securityCallback
+      ) {
+        const callback = securityCallback
+        callback(error)
+        errorThrown = true
+      }
     }
 
     // Handle SyntaxErrors
 
     const syntaxCallback = callbacks.client["syntax"]
-    if (e instanceof SyntaxError && !!syntaxCallback) {
-      syntaxCallback(e)
+    if (error instanceof SyntaxError && !!syntaxCallback) {
+      syntaxCallback(error)
       errorThrown = true
     }
 
     if (
-      (e instanceof TypeError ||
+      (error instanceof TypeError ||
         isDOMExceptionError ||
-        e instanceof SyntaxError) &&
+        error instanceof SyntaxError) &&
       !!allFailureCallback
     ) {
       errorThrown = true
-      allFailureCallback(e)
+      allFailureCallback(error)
     }
   }
 
   // Handle specific status errors
 
-  if (e.status && callbacks.status && callbacks.status[e.status]) {
-    const callback = callbacks.status[e.status]
-    callback(e)
+  const isResponse = !(error instanceof Error) && error.status
+
+  if (isResponse && callbacks.status && callbacks.status[error.status]) {
+    const callback = callbacks.status[error.status]
+    callback(error)
     errorThrown = true
   }
 
   // Handle other status errors
 
   if (
-    e.status &&
+    isResponse &&
     callbacks.status &&
-    !callbacks.status[e.status] &&
+    !callbacks.status[error.status] &&
     callbacks.status.other
   ) {
     const callback = callbacks.status.other
-    callback(e)
+    callback(error)
     errorThrown = true
   }
 
   // Handle all status errors
 
-  if (e.status && callbacks.status && callbacks.status.all) {
+  if (isResponse && callbacks.status && callbacks.status.all) {
     const callback = callbacks.status.all
-    callback(e)
+    callback(error)
     errorThrown = true
   }
 
   // Handle any custom field server errors
 
-  Object.keys(e).forEach((key) => {
-    if (key !== "status" && callbacks.body && callbacks.body[key]) {
-      const callback = callbacks.body[key]
-      callback(e, e[key])
-      errorThrown = true
-    }
-  })
+  if (error instanceof Object) {
+    Object.keys(error).forEach((key) => {
+      if (key !== "status" && callbacks.body && callbacks.body[key]) {
+        const callback = callbacks.body[key]
+        callback(error[key as keyof typeof error], error)
+        errorThrown = true
+      }
+    })
+  }
 
   // Handle other errors
   if (!errorThrown && callbacks.other) {
     const callback = callbacks.other
-    callback(e)
+    callback(error)
   }
 
   // Handle all errors
   if (callbacks.all) {
     const callback = callbacks.all
-    callback(e)
+    callback(error)
   }
 }
 

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -1,6 +1,6 @@
 export type FetchyResponse<T> =
-  | [T, undefined, Response]
-  | [undefined, FetchyError, Response]
+  | [data: T, error: undefined, response: Response]
+  | [data: undefined, error: FetchyError, response: Response]
 
 export type FetchyError = Error | ({ status: number } & Record<string, any>)
 
@@ -82,7 +82,7 @@ export type CallbackConfig = {
     all?: (e?: any) => void
   }
   body?: {
-    [key: string | number]: (value?: any, e?: any) => void
+    [key: string]: (value?: any, e?: any) => void
   }
   client?: {
     fetch?: (e?: any) => void

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
# v2.0.0 

1. Changes the return schema of the four HTTP methods.
2. The `handleError` method is included in the default export.

Re: return schema...

- Instead of an object, an array is returned. 
- The array is composed of `[data, error, response]`

```typescript
type FetchyResponse<T> =
  | [T, undefined, Response]
  | [undefined, FetchyError, Response]

type FetchyError = Error | ({ status: number } & Record<string, any>)
```
- Errors are returned rather than thrown, removing the need for try/catch blocks
- The response is always included in the returned array for additional response handling. 