### PR TITLE
v2.0.1 export handleError so it can be imported solely

### DIFF
--- a/fetchy.spec.ts
+++ b/fetchy.spec.ts
@@ -1,4 +1,4 @@
-import fetchy from "./fetchy"
+import fetchy, { handleError } from "./fetchy"
 
 async function mockResponse(body: any) {
   return new Promise((_, reject) => reject(body))
@@ -11,7 +11,7 @@ describe("fetchy.handleError", () => {
 
     const error = { status: 401 }
 
-    fetchy.handleError(error, {
+    handleError(error, {
       status: { 401: callback401, 409: callback409 },
     })
 

--- a/fetchy.ts
+++ b/fetchy.ts
@@ -96,7 +96,7 @@ export type CallbackConfig = {
   all?: (e?: any) => void
 }
 
-function handleError(error: FetchyError, callbacks: CallbackConfig) {
+export function handleError(error: FetchyError, callbacks: CallbackConfig) {
   let errorThrown = false
   // Handle non-server errors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
Export `handleError` from main file so it can be imported solely, not requiring users to import entire package.