### PR TITLE
v2.1.0 Fix json parse bug

### DIFF
--- a/fetchy.ts
+++ b/fetchy.ts
@@ -21,12 +21,14 @@ async function getResponseData<T>(response: Response) {
 async function maybeReturnError<T>(
   response: Response
 ): Promise<FetchyResponse<T>> {
+  const isJsonResponse = response.headers.get("content-type")?.includes("json")
+
   if (response.ok) {
     return [await getResponseData<T>(response), undefined, response]
-  } else {
+  } else if (isJsonResponse) {
     const parsedResponse = await response.json()
     return [undefined, { status: response.status, ...parsedResponse }, response]
-  }
+  } else return [undefined, response, response]
 }
 
 function returnError<T>(response: Response, e: any): FetchyResponse<T> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
In 2.0.0, the check of whether or not the response includes JSON was removed. This led to the function being non-responsive in certain error cases. This PR adds that check back.