### PR TITLE
v2.2.0 Fix bug with default type

### DIFF
--- a/fetchy.ts
+++ b/fetchy.ts
@@ -50,25 +50,16 @@ async function makeRequest<T>(
 }
 
 const fetchy = {
-  get: async <T = unknown>(
-    url: string,
-    options?: Omit<RequestInit, "method">
-  ) => {
+  get: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
     return makeRequest<T>(url, "GET", options)
   },
-  put: async <T = unknown>(
-    url: string,
-    options?: Omit<RequestInit, "method">
-  ) => {
+  put: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
     return makeRequest<T>(url, "PUT", options)
   },
-  post: async <T = unknown>(
-    url: string,
-    options?: Omit<RequestInit, "method">
-  ) => {
+  post: async <T = any>(url: string, options?: Omit<RequestInit, "method">) => {
     return makeRequest<T>(url, "POST", options)
   },
-  delete: async <T = unknown>(
+  delete: async <T = any>(
     url: string,
     options?: Omit<RequestInit, "method">
   ) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gladknee/fetchy",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A zero dependency wrapper for fetch that provides type-safe returns and custom error handling",
   "main": "dist/fetchy.js",
   "types": "dist/fetchy.d.ts",


### PR DESCRIPTION
The default type on the main four methods was `unknown` which resulted in type errors. This changes the default to `any` which removes those issues.